### PR TITLE
Enable SMTP email with HTML templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # FinMate
+
+This project is a personal finance management application.
+
+## Email Configuration
+
+FinMate sends verification and password reset emails using SMTP. Configure the following environment variables in `.env` or your environment:
+
+```
+EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+EMAIL_HOST=smtp.example.com
+EMAIL_PORT=587
+EMAIL_USE_TLS=True
+EMAIL_HOST_USER=your_username
+EMAIL_HOST_PASSWORD=your_password
+DEFAULT_FROM_EMAIL=noreply@finmate.com
+```
+
+When running locally without an SMTP server you can use [MailHog](https://github.com/mailhog/MailHog) or another local SMTP service.

--- a/backend/api/templates/email/password_reset_email.html
+++ b/backend/api/templates/email/password_reset_email.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <body style="font-family: Arial, sans-serif;">
+    <h2>Reset Your FinMate Password</h2>
+    <p>Hi {{ user.first_name|default:user.email }},</p>
+    <p>We received a request to reset your FinMate password. Click the button below to proceed:</p>
+    <p style="text-align:center;">
+      <a href="http://localhost:5173/password-reset/{{ user.verification_token }}" style="padding:10px 20px;background-color:#4CAF50;color:#fff;text-decoration:none;border-radius:4px;">Reset Password</a>
+    </p>
+    <p>If you didn't request a password reset, you can safely ignore this email.</p>
+    <p>Best regards,<br/>The FinMate Team</p>
+  </body>
+</html>

--- a/backend/api/templates/email/verification_email.html
+++ b/backend/api/templates/email/verification_email.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <body style="font-family: Arial, sans-serif;">
+    <h2>Welcome to FinMate!</h2>
+    <p>Hi {{ user.first_name|default:user.email }},</p>
+    <p>Thank you for registering with FinMate. Please verify your email by clicking the button below:</p>
+    <p style="text-align:center;">
+      <a href="http://localhost:5173/verify-email/{{ user.verification_token }}" style="padding:10px 20px;background-color:#4CAF50;color:#fff;text-decoration:none;border-radius:4px;">Verify Email</a>
+    </p>
+    <p>If you did not create an account, please ignore this email.</p>
+    <p>Best regards,<br/>The FinMate Team</p>
+  </body>
+</html>

--- a/backend/api/utils.py
+++ b/backend/api/utils.py
@@ -1,18 +1,35 @@
-from django.core.mail import send_mail
+from django.core.mail import EmailMultiAlternatives
+from django.template.loader import render_to_string
 from django.conf import settings
 
 def send_verification_email(user):
     """Send email verification link to the user."""
     subject = "Verify Your FinMate Email"
-    message = f"Click the link to verify your email: http://localhost:5173/verify-email/{user.verification_token}"
+    text_message = (
+        f"Click the link to verify your email: "
+        f"http://localhost:5173/verify-email/{user.verification_token}"
+    )
+    html_message = render_to_string(
+        "email/verification_email.html",
+        {"user": user},
+    )
     email_from = settings.DEFAULT_FROM_EMAIL
-    recipient_list = [user.email]
-    send_mail(subject, message, email_from, recipient_list)
+    msg = EmailMultiAlternatives(subject, text_message, email_from, [user.email])
+    msg.attach_alternative(html_message, "text/html")
+    msg.send()
 
 def send_password_reset_email(user):
     """Send password reset link to the user."""
     subject = "Reset Your FinMate Password"
-    message = f"Click the link to reset your password: http://localhost:5173/password-reset/{user.verification_token}"
+    text_message = (
+        f"Click the link to reset your password: "
+        f"http://localhost:5173/password-reset/{user.verification_token}"
+    )
+    html_message = render_to_string(
+        "email/password_reset_email.html",
+        {"user": user},
+    )
     email_from = settings.DEFAULT_FROM_EMAIL
-    recipient_list = [user.email]
-    send_mail(subject, message, email_from, recipient_list)
+    msg = EmailMultiAlternatives(subject, text_message, email_from, [user.email])
+    msg.attach_alternative(html_message, "text/html")
+    msg.send()

--- a/backend/finmate_backend/settings.py
+++ b/backend/finmate_backend/settings.py
@@ -22,14 +22,16 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 environ.Env.read_env(str(BASE_DIR / '.env'))
 
-# EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-# EMAIL_HOST = os.getenv("EMAIL_HOST")
-# EMAIL_PORT = os.getenv("EMAIL_PORT")
-# EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS")
-# EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")
-# EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
-# DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL")
+EMAIL_BACKEND = env(
+    "EMAIL_BACKEND",
+    default="django.core.mail.backends.smtp.EmailBackend",
+)
+EMAIL_HOST = env("EMAIL_HOST", default="localhost")
+EMAIL_PORT = env("EMAIL_PORT", default=25, cast=int)
+EMAIL_USE_TLS = env("EMAIL_USE_TLS", default=False, cast=bool)
+EMAIL_HOST_USER = env("EMAIL_HOST_USER", default="")
+EMAIL_HOST_PASSWORD = env("EMAIL_HOST_PASSWORD", default="")
+DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default="noreply@finmate.com")
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.2/howto/deployment/checklist/
@@ -272,11 +274,3 @@ CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 CELERY_TIMEZONE = TIME_ZONE
 
-# Email Configuration for Production (uncomment when ready)
-# EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-# EMAIL_HOST = env('EMAIL_HOST', default='smtp.gmail.com')
-# EMAIL_PORT = env('EMAIL_PORT', default=587, cast=int)
-# EMAIL_USE_TLS = env('EMAIL_USE_TLS', default=True, cast=bool)
-# EMAIL_HOST_USER = env('EMAIL_HOST_USER', default='')
-# EMAIL_HOST_PASSWORD = env('EMAIL_HOST_PASSWORD', default='')
-# DEFAULT_FROM_EMAIL = env('DEFAULT_FROM_EMAIL', default='noreply@finmate.com')


### PR DESCRIPTION
## Summary
- update settings to read SMTP credentials from environment
- use HTML templates for verification and password reset emails
- document email setup in README